### PR TITLE
British voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ $ npm install google-home-notifier
 var googlehome = require('google-home-notifier');
 
 googlehome.device('Google Home'); // Change to your Google Home name
+googlehome.accent('us'); // optional: 'us'= american voice (default), 'uk'= british voice
 googlehome.notify('Hey Foo', function(res) {
   console.log(res);
 });
@@ -62,5 +63,3 @@ Browser.defaultResolverSequence = [
 , rst.makeAddressesUnique()
 ];
 ```
-
-

--- a/example.js
+++ b/example.js
@@ -7,6 +7,7 @@ const serverPort = 8080;
 
 var deviceName = 'Google Home';
 googlehome.device(deviceName);
+// googlehome.accent('uk'); // uncomment for british voice
 
 var urlencodedParser = bodyParser.urlencoded({ extended: false });
 

--- a/google-home-notifier.js
+++ b/google-home-notifier.js
@@ -1,12 +1,18 @@
 var Client = require('castv2-client').Client;
 var DefaultMediaReceiver = require('castv2-client').DefaultMediaReceiver;
 var mdns = require('mdns');
-var googletts = require('google-tts-api');
 var browser = mdns.createBrowser(mdns.tcp('googlecast'));
 var deviceAddress;
 var device = function(name) {
     device = name;
     return this;
+}
+
+var googletts = require('google-tts-api');
+var googlettsaccent = 'us';
+var accent = function(accent) {
+  googlettsaccent = accent;
+  return this;
 }
 
 var notify = function(message, callback) {
@@ -30,7 +36,7 @@ var notify = function(message, callback) {
 }
 
 var getSpeechUrl = function(text, host, callback) {
-  googletts(text, 'en', 1).then(function (url) {
+  googletts(text, 'en', 1, 1000, googlettsaccent).then(function (url) {
     onDeviceUp(host, url, function(res){
       callback(res)
     });
@@ -63,4 +69,5 @@ var onDeviceUp = function(host, url, callback) {
 }
 
 exports.device = device;
+exports.accent = accent;
 exports.notify = notify;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "body-parser": "^1.15.2",
     "castv2-client": "^1.1.2",
     "express": "^4.14.0",
-    "google-tts-api": "0.0.1",
+    "google-tts-api": "https://github.com/darrencruse/google-tts/tarball/british-voice",
     "mdns": "^2.3.3",
     "ngrok": "^2.2.4"
   }


### PR DESCRIPTION
Hi Noel -

This PR shouldn't be merged as I'm waiting on my PR against the google-tts-api module, but here's a preview if you're interested that adds an option to use the british voice from google translate instead of the default american one.

I'm actually not british btw I've just been playing with your module to do spoken medicine reminders for my mom, and I was getting tired of hearing the american voice all the time! 

Originally I'd hoped maybe there was an option for a male voice or something but googling it seemed this still-female-but-british-accent-voice is the only other option possible. But it was easy to do and I thought - what the heck better than no other option at all...

Hope you're interested.

I've done it very simply imitating your "device" function but adding another function called "accent" that takes "us" or "uk" that they can call to switch the voice.  It defaults to the american voice if they don't call it (i.e. so it stays the same as now).  

For my medicine reminder I'm using a variation of your example.js with IFTTT.com - I had a thought of maybe letting them stick like an optional prefix i.e. "uk:Hello Google Home" on the actual spoken text so that it would be super easy to switch right inside the IFTTT applet configuration.  

But I wasn't 100% sure others would care about that (i.e. I thought they might just be happy to set it once using this "accent" call so they're choosing their voice for everything not each time they speak something).  So I didn't do that after all I kept it simple.

If you want to try it this should work for you btw because I've pointed package.json at my branch of google-tts-api.  If they merge my PR there I will update package.json here and update my comments here in case you wish to merge this for real.

