### PR TITLE
Fix parameter

### DIFF
--- a/google-home-notifier.js
+++ b/google-home-notifier.js
@@ -11,8 +11,9 @@ var device = function(name, lang = 'en') {
     return this;
 };
 
-var ip = function(ip) {
+var ip = function(ip, lang = 'en') {
   deviceAddress = ip;
+  language = lang;
   return this;
 }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "body-parser": "^1.15.2",
     "castv2-client": "^1.1.2",
     "express": "^4.14.0",
-    "google-tts-api": "https://github.com/darrencruse/google-tts/tarball/british-voice",
+    "google-tts-api": "0.0.2",
     "mdns": "^2.3.3",
     "ngrok": "^2.2.4"
   }


### PR DESCRIPTION
In your example, there was `lang` in the parameter of `ip()`. However, it was not defined in library `ip()`.