### PR TITLE
Add resolverSequence

### DIFF
--- a/google-home-notifier.js
+++ b/google-home-notifier.js
@@ -1,7 +1,12 @@
 var Client = require('castv2-client').Client;
 var DefaultMediaReceiver = require('castv2-client').DefaultMediaReceiver;
 var mdns = require('mdns');
-var browser = mdns.createBrowser(mdns.tcp('googlecast'));
+var sequence = [
+    mdns.rst.DNSServiceResolve(),
+    'DNSServiceGetAddrInfo' in mdns.dns_sd ? mdns.rst.DNSServiceGetAddrInfo() : mdns.rst.getaddrinfo({families:[4]}),
+    mdns.rst.makeAddressesUnique()
+];
+var browser = mdns.createBrowser(mdns.tcp('googlecast'), {resolverSequence: sequence});
 var deviceAddress;
 var language;
 


### PR DESCRIPTION
This patch replaces resolverSeqeuce of node_mdns from defaultResolverSequence, so there is no need to [modify "node_modules/mdns/lib/browser.js"](https://github.com/noelportugal/google-home-notifier#after-npm-install).