### PR TITLE
Surround url with double quotes in `example.js`

### DIFF
--- a/example.js
+++ b/example.js
@@ -101,8 +101,8 @@ app.listen(serverPort, function () {
     console.log('    http://' + ip + ':' + serverPort + '/google-home-notifier');
     console.log('    ' + url + '/google-home-notifier');
     console.log('GET example:');
-    console.log('curl -X GET ' + url + '/google-home-notifier?text=Hello+Google+Home');
-	console.log('POST example:');
-	console.log('curl -X POST -d "text=Hello Google Home" ' + url + '/google-home-notifier');
+    console.log('curl -X GET "' + url + '/google-home-notifier?text=Hello+Google+Home"');
+    console.log('POST example:');
+    console.log('curl -X POST -d "text=Hello Google Home" "' + url + '/google-home-notifier"');
   });
 })


### PR DESCRIPTION
When execute `example.js` file, there is output like the one below.

```
Endpoints:
    http://192.168.0.106:8091/google-home-notifier
    https://8be99288.ngrok.io/google-home-notifier
GET example:
curl -X GET https://8be99288.ngrok.io/google-home-notifier?text=Hello+Google+Home
POST example:
curl -X POST -d text=Hello Google Home" "https://8be99288.ngrok.io/google-home-notifier
```

`curl -X GET https://8be99288.ngrok.io/google-home-notifier?text=Hello+Google+Home` can not execute in my shell (I'm using [fish](https://github.com/fish-shell/fish-shell)), but It can execute when surrounded url with double quotes.