### PR TITLE
fix: Error: get key failed from google

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "body-parser": "^1.15.2",
     "castv2-client": "^1.1.2",
     "express": "^4.14.0",
-    "google-tts-api": "0.0.2",
+    "google-tts-api": "^0.0.4",
     "mdns": "^2.3.3",
     "ngrok": "^2.2.4"
   }


### PR DESCRIPTION
Fixes: `Error: get key failed from google` due to an outdated `google-tts-api` dependency.